### PR TITLE
Initial track PUBLISH/SUBSCRIBE

### DIFF
--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -466,43 +466,41 @@ A SEGMENT message contains a single segment associated with a specified track, a
 The format of the SEGMENT message is as follows:
 
 ~~~
-SEGMENT Header {
-  Header Name Length (8),
-  Header Name (..),
-  Header Value Length (i),
-  Header Value (..),
-}
-
 SEGMENT Message {
   Track ID (i),
-  Number of Segment Headers (i),
-  Segment Headers (..) ...,
-  Segment Payload (..)
+  Segment ID (i),
+  Order (i),
+  Dependency Count (i)
+  Dependency Segment IDs (..)
+  Payload (..)
 }
 ~~~
 {: #warp-segment-format title="Warp SEGMENT Message"}
 
 This document defines the following headers:
 
-* `track_id`.
+* Track ID:
 The track identifier.
-When using a container with an initialization payload, the decoder MUST block until the cooresponding PUBLISH message ({{publish}}) has been received.
+The decoder SHOULD block until the cooresponding PUBLISH message ({{publish}}) has been received.
 
-* `segment_id`.
+* Segment ID:
 A unique identifier for each segment within a track.
 It is RECOMMENDED that this is an monotonically increasing sequence number, but the receiver MUST NOT assume that it is.
 
-* `order`.
+* Order:
 An integer indicating the delivery order ({{delivery-order}}).
-This field is optional; the default value is 0.
 
-* `depends`.
-An list of dependencies by `segment_id` ({{dependencies}}).
-This field is optional; an empty array indicates the segment is independent.
+* Dependency Count:
+The number of dependency segment IDs that follow.
+A synchronization point (ex. i-frame) will have zero dependencies.
 
-The remainder of the SEGMENT message is a payload depending on the track `mime_type`.
+* Dependency Segment IDs:
+An list dependencies by Segment ID ({{dependencies}}), each of which is a variable integer.
+The decoder SHOULD block until the cooresponding SEGMENT messages have been received.
+
+* Payload:
+The format depends on the track container type ({{containers}}).
 This contains a media bitstream intended for the decoder and SHOULD NOT be processed by a relay.
-See the containers section ({{containers}}).
 
 
 ## PUBLISH {#publish}
@@ -565,12 +563,12 @@ An identifier for the subscription.
 A subscription MAY be updated by sending a SUBSCRIBE message with the same Subscribe ID.
 
 * Track Count
-The number of track IDs that follow, which are variable integers.
+The number of track IDs that follow.
 
 * Track IDs
-A list of track identifiers, at least one of which SHOULD be transmitted.
+A list of track identifiers, each of which is a variable integer.
 The receiver SHOULD arrange the list in preferred order; for example 1080p takes precidence over 480p.
-The sender SHOULD choose the track to transmit based on this preferred order, the track availablity, and network conditions.
+The sender SHOULD transmit at least one track based on this preferred order, the track availablity, and network conditions.
 
 
 When no tracks are specified, the receiver indicates that it wants to cancel the subscription with the same ID.

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -332,7 +332,7 @@ Warp endpoints communicate over QUIC streams. Every stream is a sequence of mess
 The first stream opened is a client-initiated bidirectional stream where the peers exchange SETUP messages ({{setup}}). The subsequent streams MAY be either unidirectional and bidirectional. For exchanging media, an application would typically send a unidirectional stream containing a single SEGMENT message ({{segment}}).
 
 Messages SHOULD be sent over the same stream if ordering is desired.
-For example, ANNOUNCE\_TRACK and SUBSCRIBE\_TRACK messages SHOULD be sent on the same stream to avoid a race.
+For example, PUBLISH\_TRACK and SUBSCRIBE\_TRACK messages SHOULD be sent on the same stream to avoid a race.
 
 ## Prioritization
 Warp utilizes stream prioritization to deliver the most important content during congestion.
@@ -421,7 +421,7 @@ The Message Length field contains the length of the Message Payload field in byt
 |------|----------------------------------------|
 | 0x1  | SETUP ({{setup}})                      |
 |------|----------------------------------------|
-| 0x2  | ANNOUNCE\_TRACK ({{announce-track}})   |
+| 0x2  | PUBLISH\_TRACK ({{publish-track}})   |
 |------|----------------------------------------|
 | 0x3  | SUBSCRIBE\_TRACK ({{subscribe-track}}) |
 |------|----------------------------------------|
@@ -481,7 +481,7 @@ This document defines the following headers:
 
 * Track ID:
 The track identifier.
-The decoder SHOULD block until the cooresponding ANNOUNCE\_TRACK message ({{announce-track}}) has been received.
+The decoder SHOULD block until the cooresponding PUBLISH\_TRACK message ({{publish-track}}) has been received.
 
 * Segment ID:
 A unique identifier for each segment within a track.
@@ -503,12 +503,12 @@ The format depends on the track format ({{track-format}}).
 This contains a media bitstream intended for the decoder and SHOULD NOT be processed by a relay.
 
 
-## ANNOUNCE\_TRACK {#announce-track}
-The sender advertises an available track via the ANNOUNCE\_TRACK message.
+## PUBLISH\_TRACK {#publish-track}
+The sender advertises an available track via the PUBLISH\_TRACK message.
 The receiver can ask for tracks via the SUBSCRIBE\_TRACK ({{subscribe-track}}) message based on this information.
 
 ~~~
-ANNOUNCE\_TRACK Message {
+PUBLISH\_TRACK Message {
   Track ID (i),
   Track Format (i),
   Max Bitrate (i),
@@ -516,13 +516,13 @@ ANNOUNCE\_TRACK Message {
   Init Payload (..),
 }
 ~~~
-{: #warp-publish-format title="Warp ANNOUNCE\_TRACK Message"}
+{: #warp-publish-format title="Warp PUBLISH\_TRACK Message"}
 
-Each ANNOUNCE\_TRACK message starts with a header, containing information useful for a relay:
+Each PUBLISH\_TRACK message starts with a header, containing information useful for a relay:
 
 * Track ID:
 An identifier for the track.
-The track MAY be updated by sending a ANNOUNCE\_TRACK message with the same Track ID.
+The track MAY be updated by sending a PUBLISH\_TRACK message with the same Track ID.
 
 * Track Format:
 The track format, as defined in {{track-format}}.
@@ -657,7 +657,7 @@ A Common Media Application Format Segment {{CMAF}} meets all these requirements.
 Media fragments can be packaged at any frequency, causing a trade-off between overhead and latency.
 It is RECOMMENDED that a media fragment consists of a single frame to minimize latency.
 
-The ANNOUNCE\_TRACK message ({{announce-track}}) payload MUST be an initization segment.
+The PUBLISH\_TRACK message ({{publish-track}}) payload MUST be an initization segment.
 The SEGMENT message ({{segment}}) payload MUST be a media segment, which consists of any number of media fragments.
 
 # Security Considerations

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -403,7 +403,7 @@ TODO document the encoding
 |-----:|:--------------------------|
 | 0x0  | SEGMENT ({{segment}})     |
 |------|---------------------------|
-| 0x1  | TRACK ({{track}})         |
+| 0x1  | PUBLISH ({{publish}})     |
 |------|---------------------------|
 | 0x2  | SUBSCRIBE ({{subscribe}}) |
 |------|---------------------------|
@@ -418,7 +418,7 @@ Each SEGMENT message starts with a header, containing information useful for a r
 
 * `track_id`.
 The track identifier. {{track}}
-A decoder MUST block until the cooresponding `TRACK` message has been received.
+A decoder MUST block until the cooresponding PUBLISH message has been received.
 
 * `order`.
 An integer indicating the delivery order ({{delivery-order}}).
@@ -437,14 +437,14 @@ This contains a media bitstream intended for the decoder and SHOULD NOT be proce
 See the containers section ({{containers}}).
 
 
-## TRACK
-The sender advertises available tracks via the TRACK message.
+## PUBLISH
+The sender advertises an available track via the PUBLISH message.
 The receiver can ask for tracks via the SUBSCRIBE ({{subscribe}}) message based on this information.
 
-Tracks MAY be updated by sending a new TRACK message with an existing `track_id`.
-TRACK messages with the same `track_id` SHOULD be sent over the same stream to preserve ordering.
+Tracks MAY be updated by sending a new PUBLISH message with an existing `track_id`.
+PUBLISH messages with the same `track_id` SHOULD be sent over the same stream to preserve ordering.
 
-Each TRACK message starts with a header, containing information useful for a relay:
+Each PUBLISH message starts with a header, containing information useful for a relay:
 
 * `track_id`.
 A unique identifier for the track.
@@ -472,13 +472,13 @@ This field is optional, but RECOMMENDED when there are multiple tracks in the sa
 An identifier for the payload, useful for backwards compatibility with HTTP caches.
 This field is optional.
 
-The remainder of the TRACK message is a payload depending on the `mime_type`.
+The remainder of the PUBLISH message is a payload depending on the `mime_type`.
 This contains any information required to initialize the decoder and SHOULD NOT be processed by a relay.
 See the containers section ({{containers}}).
 
 ## SUBSCRIBE
 The receiver sends a SUBSCRIBE message to indicate that it wishes to receive tracks.
-This MUST coorespond to an existing TRACK ({{track}}) message from the sender.
+This MUST coorespond to an existing PUBLISH ({{publish}}) message from the sender.
 
 * `subscribe_id`.
 A identifier for the SUBSCRIBE message.
@@ -524,7 +524,7 @@ Future drafts and extensions may specify additional containers.
 ## fMP4
 The `video/mp4` and `audio/mp4` mimetype indicate a fragmented MP4 container {{ISOBMFF}}.
 
-The TRACK message ({{track}}) payload MUST be an initization segment.
+The PUBLISH message ({{track}}) payload MUST be an initization segment.
 The SEGMENT message ({{segment}}) payload MUST be a media segment, which consists of any number of media fragments.
 
 An initialization segment consists of a File Type Box (ftyp) followed by a Movie Box (moov).

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -528,7 +528,7 @@ An identifier for the track.
 The track MAY be updated by sending a PUBLISH message with the same Track ID.
 
 * Container Type:
-The container type, as defined in {{containers}}.
+The container type, as defined in Containers ({{containers}}).
 
 * Group ID:
 An identifier indicating that this track is part of a group.
@@ -653,9 +653,6 @@ Future drafts and extensions may specify additional containers.
 ## fMP4
 A fragmented MP4 container {{ISOBMFF}}.
 
-The PUBLISH message ({{publish}}) payload MUST be an initization segment.
-The SEGMENT message ({{segment}}) payload MUST be a media segment, which consists of any number of media fragments.
-
 An initialization segment consists of a File Type Box (ftyp) followed by a Movie Box (moov).
 This Movie Box (moov) consists of Movie Header Boxes (mvhd), Track Header Boxes (tkhd), Track Boxes (trak), followed by a final Movie Extends Box (mvex).
 These boxes MUST NOT contain any samples and MUST have a duration of zero.
@@ -668,6 +665,9 @@ A Common Media Application Format Segment {{CMAF}} meets all these requirements.
 
 Media fragments can be packaged at any frequency, causing a trade-off between overhead and latency.
 It is RECOMMENDED that a media fragment consists of a single frame to minimize latency.
+
+The PUBLISH message ({{publish}}) payload MUST be an initization segment.
+The SEGMENT message ({{segment}}) payload MUST be a media segment, which consists of any number of media fragments.
 
 # Security Considerations
 


### PR DESCRIPTION
Closes #13 #12 

This covers a few use-cases:

1. The sender can advertise support for multiple codecs/containers.
2. The receiver can request a specific track, for example: english or japannese audio.
3. The receiver can request one of many tracks, so the server can perform ABR. For example: one of 480p, 720p, or 1080p.
4. The receiver can request multiple tracks of the same rendition for multicast. For example: 480p, 720p, and 1080p.
5. The receiver can request only tracks it supports. For example: no 1080p due to an unsupported profile.
6. The receiver can seamlessly switch between enabled tracks. For example: send me the ad track while enabled, then switch to the content track.
7. The sender can pre-emptively send tracks before the PLAY message, avoiding a round trip.


There's a few use-cases that aren't covered:

1. The receiver wants to specify when the track should be switched (timestamp).
2. The receiver wants to go rewind and request older content for a track.