### PR TITLE
Congestion response by groups and priorities.

### DIFF
--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -260,6 +260,10 @@ Any identification, reliability, ordering, prioritization, caching, etc is writt
 This ensures that relays can easily route/fanout media to the final destination.
 
 ## Bandwidth management and congestion response
+TODO: Add motivation text regarding bw management techniques in
+response to congestion. Also refer to {{priority-congestion}} for
+further details.
+
 In point to point scenarios, it may be possible for publishers to notice network
 congestion and to manage encoding parameters to fit into the available bandwidth.
 This is generally not possible at relays, especially in cases involving large fan-out.
@@ -329,7 +333,11 @@ A receiver MUST NOT assume that objects will be received in delivery order for a
 * Packet loss or flow control MAY delay the delivery of individual streams.
 * The sender might not support QUIC stream prioritization.
 
+TODO: Refer to Congestion Response and Priorirization Section for further details on various proposals.
+
 ## Groups
+TODO: Add text describing interation of group and intra object priorities within a group and their relation to congestion response. Add how it refers to {{priority-congestion}}
+
 Objects are marked with metadata that facilitate congestion response in relays. That information
 also facilitate synchronization to intermediate points, as needing when "fast forwarding" or
 "rewinding" a media stream. Applications can define groups however they see fit, as long as the following property applies:

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -275,7 +275,9 @@ proper decoding of following frames until the next reference frame is received. 
 contrast, some interpolation frames can be dropped with little consequence. However,
 we have to assume that the media stream will often be encrypted end-to-end, and that
 relays cannot just peer into the data to understand what parts could be dropped and
-what parts should not.
+what parts should not. Even without encryption, we don't want to mandate that the
+relay understand the codec used by the media, which also imposes treating objects as
+opaque sets of bytes.
 
 A goal of this draft is to specify enough "meta data" in protocol headers to allow
 adequate congestion response in relays.
@@ -396,7 +398,7 @@ For example, attempting to use a different role than pre-negotated ({{role}}) or
 ## Streams
 Warp endpoints communicate over QUIC streams. Every stream is a sequence of messages, framed as described in {{messages}}.
 
-The first stream opened is a client-initiated bidirectional stream where the peers exchange SETUP messages ({{message-setup}}). The subsequent streams MAY be either unidirectional and bidirectional. For exchanging media, an application would typically send a unidirectional stream containing all the OBJECT messages ({{message-object}}) belonging to a single group.
+The first stream opened is a client-initiated bidirectional stream where the peers exchange SETUP messages ({{message-setup}}). The subsequent streams MAY be either unidirectional and bidirectional. For exchanging media, OBJECT messages belonging to a group are delivered over one or more unidirectional streams based on application's preferred mapping of the OBJECT's group to underlying QUIC Stream(s).
 
 
 Messages SHOULD be sent over the same stream if ordering is desired.

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -501,7 +501,8 @@ The format of the OBJECT message is as follows:
 OBJECT Message {
   Broadcast URI (b)
   Track ID (i),
-  Object ID (i),
+  Group Sequence (i),
+  Object Sequence (i),
   Object Delivery Order (i),
   Object Payload (b),
 }
@@ -514,8 +515,13 @@ The broadcast URI as declared in CATALOG ({{message-catalog}}).
 * Track ID:
 The track identifier as declared in CATALOG ({{message-catalog}}).
 
-* Object ID:
-A unique identifier for each object within the track.
+* Group Sequence :
+An integer always starts at 0 and increases sequentially at the original media publisher.
+Group sequences are scoped under a Track.
+
+* Object Sequence:
+An integer always starts at 0 with in a Group and increases sequentially.
+Object Sequences are scoped to a Group.
 
 * Object Delivery Order:
 An integer indicating the object delivery order ({{delivery-order}}).

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -330,10 +330,8 @@ A receiver MUST NOT assume that objects will be received in delivery order for a
 ## Groups
 Objects are marked with metadata that facilitate congestion response in relays. That information
 also facilitate synchronization to intermediate points, as needing when "fast forwarding" or
-"rewinding" a media stream. In warp, this is implemented by arranging objects in groups, with the
-following properties:
+"rewinding" a media stream. Applications can define groups however they see fit, as long as the following property applies:
 
-* The beginning of a group is a potential synchronization point,
 * If a decoder has received all previous objects from the beginning of a group
   up to the current one, then the current one can be properly decoded and rendered.
 

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -436,7 +436,7 @@ Both unidirectional and bidirectional Warp streams are sequences of length-delim
 ~~~
 Warp Message {
   Message Type (i),
-	Message Length (i),
+  Message Length (i),
   Message Payload (..),
 }
 ~~~


### PR DESCRIPTION
This is a PR to address issue #58. It presents how markings of groups can be used for congestion responses, and introduces a potential discussion of submarkings within groups.