### PR TITLE
Control channel for track management and Subscribe updates

### DIFF
--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -346,11 +346,11 @@ Warp endpoints communicate over QUIC streams. Every stream is a sequence of mess
 
 ### Control and Data Channels
 
-When a endpoint client or relay begins a transaction with the relay/origin, new bilateral QUIC Stream is opened. This stream will act as the "control channel" for the exchange of data, carrying a series of control messages in both directions. There is one control channel setup per emission/subscription. Control Channels are "one way" and are setup hop-by-hop between the participating MoQ entities (endpoints, relays, origin,...). If a peer both sends and receive media, there will be different control channels for sending and receiving.
+When a endpoint client or relay begins a transaction with the relay/origin for media delivery, a new bilateral QUIC Stream is opened. This stream will act as the "Control Channel" for the exchange of data, carrying a series of control messages in both directions. There is one "Control Channel" setup per track. Control Channels are "one way" and are setup hop-by-hop between the participating MoQ entities. If a peer both sends and receive media, there will be different control channels for sending and receiving.
 
-For exchanging media, OBJECT messages ({{message-object}}) belonging to a group are delivered over one or more unidirectional streams, called data channels,  based on application's preferred mapping of the OBJECT's group to underlying QUIC Stream(s).
+For exchanging media, OBJECT messages ({{message-object}}) belonging to a group are delivered over one or more unidirectional streams, called data channels, based on application's preferred mapping of the OBJECT and its group to underlying QUIC Stream(s).
 
-The control channel will remain open as long as the peers are still sending or receiving the media. If either peer closes the control stream, the other peer will close its end of the stream and discard the state associated with the media transfer. The latter resulting in termination or clean up of stream states associated with the date channels.
+The control channel will remain open as long as the peers are still sending or receiving the media. If either peer closes the control stream, the other peer will close its end of the stream and discard the state associated with the media transfer. The latter resulting in termination or clean up of stream states associated with the data channels.
 
 ## Prioritization
 Warp utilizes stream prioritization to deliver the most important content during congestion.
@@ -500,17 +500,19 @@ The SETUP parameters are described in the {{setup-parameters}} section.
 
 ## Subscribing to the media
 
-Entities that intend to receive objects will do so via subscriptions. Subscriptions are sent from the end-point clients and/or Relays to the Origin (via relays, if present) and are typically processed by the Relays. Subscriptions are sent over the control channel that is set up for a given SubscriptionId.  All the subscriptions MUST be authorized at the Origin Server and/or possibly at the Edge Relay (if trusted via the out-of-band configuration).
+Entities that intend to receive objects will do so via subscriptions. Subscriptions are sent from the end-point clients and/or Relays to the Origin (via relays, if present) and are typically processed by the Relays. Subscriptions are sent over the control channel that is set up for a given SubscriptionId. All the subscriptions MUST be authorized at the Origin Server and/or possibly at the Edge Relay (if trusted via the out-of-band configuration).
 
 ### SUBSCRIBE {#message-subscribe}
 
-The format of SUBSCRIBE is defined as below
+The format of SUBSCRIBE control message is defined as below
 
 ~~~
 SUBSCRIBE Message {
   Subscription ID Length(i),
   Subscription ID (...)...,  
   Media ID (i),
+  [Group ID (i)],
+  [Object ID(i)],
   Encrypted Payload Length(i),
   Encrypted Payload (...)...
 }
@@ -519,14 +521,13 @@ SUBSCRIBE Message {
 
 
 * Subscription ID:
-Identifies a given emission to request for authorization.
+Identifies content of interest, such as a track or emission for receiving objects. Optional fields `Group ID` and `Object ID` identifies further details corresponding to the subcribed objects.
 
 * Media ID:
 Represents an handle to the subscription to be provided by the peer over the data channel(s). Given that media corresponding to a subscription can potentially arrive over multiple data channels, the Media ID provides the necessary mapping between the control and the data channel. Media ID also serves as compression identifier for containing the size of object headers instead of carrying complete track/catalog/broadcast identifier information in every object message.
 
-* Encrypted Pyload: 
-Carries client’s authorization information obtained out-of-band. Such information typically is in form of a token authorizing client’s subscription to the given SubscriptionId. The payload may be possibly encrypted and accessible only by the Origin or the MoQ Relay depending on the configuration.
-
+* Encrypted Payload: 
+Carries client’s authorization information obtained out-of-band. Such information typically is in form of a token, authorizing client’s subscription to the given SubscriptionId. The payload may be possibly encrypted and accessible only by the Origin or the MoQ Relay depending on the configuration. For cases where the relays don't have access to the keying material for accessing the payload, the relays MUST forward the payload towards the Origin (possibly via other relays) in the onward `SUBSCRIBE` messages.
 
 Subscriptions are typically long-lived transactions and they stay active until one of the following happens:
 
@@ -534,7 +535,7 @@ Subscriptions are typically long-lived transactions and they stay active until o
 - optionally, a server policy dicates subscription expiration.
 - the underlying transport is disconnected
 
-A endpoint client can renew its subscriptions at any point by sending a new `SUBSCRIBE`. Such subscriptions MUST refresh the existing subscriptions for that name and thus only the most recent SUBSCRIBE message is considered active. A renewal period of 5 seconds is RECOMMENDED.
+A endpoint client can renew its subscriptions at any point by sending a new `SUBSCRIBE`. Such subscriptions MUST refresh the existing subscriptions and thus only the most recent SUBSCRIBE message is considered active. A renewal period of 5 seconds is RECOMMENDED.
 
 
 DISCUSS: Do we need transaction identifier ?
@@ -560,11 +561,9 @@ enum Response
 SUBSCRIBE_REPLY Message {
   Subscription ID Length(i),
   Subscription ID (...)..., 
-  Response respoonse
+  Response response,
   [Reason Phrase Length (i),
-  [Reason Phrase (..)],
-  [Relay Redirect URL Length(i)],
-  [Relay Redirect URL(...)...],
+  [Reason Phrase (...)...],
   Signature(32)
 }
 ~~~
@@ -617,13 +616,13 @@ Object Sequences are scoped to a Group.
 An integer indicating the object delivery order ({{delivery-order}}).
 
 * Flags:
-A octet bitstring capturing object's relative characteristics as defined by the application. It is made up of following components 
+A octet bitstring capturing object's relative characteristics as defined by the application. It is made up of following components:
 ```
 Flags := Reserved (2) | LatencyMode(1) | IsDiscardable (1) | Priority (3).
 ```
 LatencyMode is an hint to Relays to identify the latency profile of the media 
 being carried and has 2 possible values of "Realtime" and "NonRealTime". `IsDiscardable` 
-hint specifies if the current object can be discarded under congestion. `Priority` is a 3 bit field provididong a strict ordered priority of the objects within a given group.
+hint specifies if the current object can be discarded under congestion. `Priority` is a 3 bit field providing a strict ordered priority of the objects within a given group.
 
 * Object Payload:
 The format depends on the track container ({{containers}}).

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -510,7 +510,6 @@ The format of SUBSCRIBE control message is defined as below
 SUBSCRIBE Message {
   Subscription ID Length(i),
   Subscription ID (...)...,  
-  Media ID (i),
   [Group ID (i)],
   [Object ID(i)],
   Encrypted Payload Length(i),
@@ -522,9 +521,6 @@ SUBSCRIBE Message {
 
 * Subscription ID:
 Identifies content of interest, such as a track or emission for receiving objects. Optional fields `Group ID` and `Object ID` identifies further details corresponding to the subcribed objects.
-
-* Media ID:
-Represents an handle to the subscription to be provided by the peer over the data channel(s). Given that media corresponding to a subscription can potentially arrive over multiple data channels, the Media ID provides the necessary mapping between the control and the data channel. Media ID also serves as compression identifier for containing the size of object headers instead of carrying complete track/catalog/broadcast identifier information in every object message.
 
 * Encrypted Payload: 
 Carries client’s authorization information obtained out-of-band. Such information typically is in form of a token, authorizing client’s subscription to the given SubscriptionId. The payload may be possibly encrypted and accessible only by the Origin or the MoQ Relay depending on the configuration. For cases where the relays don't have access to the keying material for accessing the payload, the relays MUST forward the payload towards the Origin (possibly via other relays) in the onward `SUBSCRIBE` messages.
@@ -561,6 +557,7 @@ enum Response
 SUBSCRIBE_REPLY Message {
   Subscription ID Length(i),
   Subscription ID (...)..., 
+  [Media ID (i)],
   Response response,
   [Reason Phrase Length (i),
   [Reason Phrase (...)...],
@@ -575,6 +572,9 @@ Identifies the mapping subscription identifier in the SUBSCRIBE message.
 
 * Response:
 Provides result of the subscription. A response of `OK` is considered as successful subscription and the application should be ready to receive media matching the subscription. A response of `EXPIRED` or `FAIL` imply failed subscription  with further details provided in the Reason Phrase, enabling the application to take appropriate action. In the case of `REDIRECT` response, the subscriber MUST move to the Relay that is identified in the `Relay Redirect URL` to setup the subscription.
+
+* Media ID:
+Represents an handle to the subscription to be provided by the peer over the data channel(s) and is populated for successful subscriptions. Given that media corresponding to a subscription can potentially arrive over multiple data channels, the Media ID provides the necessary mapping between the control and the corresponding data channels. Media ID also serves as compression identifier for containing the size of object headers instead of carrying complete track/catalog/broadcast identifier information in every object message.
 
 * Signature: 
 Signature over all the fields up unitl the Signautre field and signed by the Origin.

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -525,13 +525,13 @@ Identifies content of interest, such as a track or emission for receiving object
 * Encrypted Payload: 
 Carries client’s authorization information obtained out-of-band. Such information typically is in form of a token, authorizing client’s subscription to the given SubscriptionId. The payload may be possibly encrypted and accessible only by the Origin or the MoQ Relay depending on the configuration. For cases where the relays don't have access to the keying material for accessing the payload, the relays MUST forward the payload towards the Origin (possibly via other relays) in the onward `SUBSCRIBE` messages.
 
-Subscriptions are typically long-lived transactions and they stay active until one of the following happens:
+Subscriptions transactions stay active until one of the following happens:
 
 - a client local policy dictates expiration of a subscription.
 - optionally, a server policy dicates subscription expiration.
 - the underlying transport is disconnected
 
-A endpoint client can renew its subscriptions at any point by sending a new `SUBSCRIBE`. Such subscriptions MUST refresh the existing subscriptions and thus only the most recent SUBSCRIBE message is considered active. A renewal period of 5 seconds is RECOMMENDED.
+A endpoint client MUST renew its subscriptions by sending a new `SUBSCRIBE` to keep them active. Such subscriptions MUST refresh the existing subscriptions and thus only the most recent SUBSCRIBE message is considered active. A renewal period of 5 seconds is RECOMMENDED.
 
 
 DISCUSS: Do we need transaction identifier ?

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -346,7 +346,7 @@ Warp endpoints communicate over QUIC streams. Every stream is a sequence of mess
 
 ### Control and Data Channels
 
-When a endpoint client or relay begins a transaction with the relay/origin, new bilateral QUIC Stream is opened. This stream will act as the "control channel" for the exchange of data, carrying a series of control messages in both directions. There is one control channel setup per track. Control Channels are "one way". If a peer both sends and receive media, there will be different control channels for sending and receiving.
+When a endpoint client or relay begins a transaction with the relay/origin, new bilateral QUIC Stream is opened. This stream will act as the "control channel" for the exchange of data, carrying a series of control messages in both directions. There is one control channel setup per emission/subscription. Control Channels are "one way" and are setup hop-by-hop between the participating MoQ entities (endpoints, relays, origin,...). If a peer both sends and receive media, there will be different control channels for sending and receiving.
 
 For exchanging media, OBJECT messages ({{message-object}}) belonging to a group are delivered over one or more unidirectional streams, called data channels,  based on application's preferred mapping of the OBJECT's group to underlying QUIC Stream(s).
 
@@ -500,7 +500,7 @@ The SETUP parameters are described in the {{setup-parameters}} section.
 
 ## Subscribing to the media
 
-Entities that intend to receive objects will do so via subscriptions. Subscriptions are sent from the end-point clients and/or Relays to the Origin (via relays, if present) and are typically processed by the Relays.  All the subscriptions MUST be authorized at the Origin Server and/or possibly at the Edge Relay (if trusted via the out-of-band configuration).
+Entities that intend to receive objects will do so via subscriptions. Subscriptions are sent from the end-point clients and/or Relays to the Origin (via relays, if present) and are typically processed by the Relays. Subscriptions are sent over the control channel that is set up for a given SubscriptionId.  All the subscriptions MUST be authorized at the Origin Server and/or possibly at the Edge Relay (if trusted via the out-of-band configuration).
 
 ### SUBSCRIBE {#message-subscribe}
 
@@ -517,11 +517,9 @@ SUBSCRIBE Message {
 ~~~
 {: #warp-subscribe-format title="Warp SUBSCRIBE Message"}
 
-After receiving a CATALOG message ({{message-catalog}}), the receiver sends a SUBSCRIBE message to indicate that it wishes to receive the indicated tracks within a broadcast.
 
 * Subscription ID:
-Identifies a given track from the Catalog or the Composition(broadcast) encompassing
-all the tracks.
+Identifies a given emission to request for authorization.
 
 * Media ID:
 Represents an handle to the subscription to be provided by the peer over the data channel(s). Given that media corresponding to a subscription can potentially arrive over multiple data channels, the Media ID provides the necessary mapping between the control and the data channel. Media ID also serves as compression identifier for containing the size of object headers instead of carrying complete track/catalog/broadcast identifier information in every object message.
@@ -539,14 +537,13 @@ Subscriptions are typically long-lived transactions and they stay active until o
 A endpoint client can renew its subscriptions at any point by sending a new `SUBSCRIBE`. Such subscriptions MUST refresh the existing subscriptions for that name and thus only the most recent SUBSCRIBE message is considered active. A renewal period of 5 seconds is RECOMMENDED.
 
 
-
 DISCUSS: Do we need transaction identifier ?
 
 DISCUSS: Should we talk about intent to subscribe on replay or syncup ?
 
 ### SUBSCRIBE_REPLY {#message-subscribe-reply}
 
-A `SUBSCRIBE_REPLY` provides result of the subscription. This message is sent by the Origin (except when redirected) when it’s successfully validates the subscription request, signs it with its public key.
+A `SUBSCRIBE_REPLY` provides result of the subscription. This message is sent by the Origin when it’s successfully validates the subscription request, also signs it with its public key.
 
 The format of SUBSCRIBE_REPLY is defined as below
 


### PR DESCRIPTION
Address #81  

This PR adds support for control channel ( a bidirectional QUIC Stream) for managing media over one or more unidirectional QUIC Streams.


This PR also 
- Updates Subscribe message
- Adds Subscribe_Reply message
- Adds Flags parameters to the Object Header for intra-group priorities and more. 

Depends in part on #95 