### PR TITLE
Merge broadcast URN with the WebTransport URL.

### DIFF
--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -181,9 +181,15 @@ The basic element of Warp is *a media object*. A media object is a single addres
 
 *A media track* in Warp is a combination of *an init object* and a sequence of media objects. An init object is a format-specific self-contained description of the track that is required to decode any media object contained within the track, but can also be used as the metadata for track selection. If two media tracks carry semantically equivalent but differently encoded media, they are referred to as *variants* of each other.
 
-*A Warp broadcast* is a collection of multiple media tracks produced by a single source. The sender has the ability to publish one or more tracks and the receiver has the ability to subscribe to zero or more tracks. Depending on the the application, the sender may decide to unilaterally push tracks without an explicit subscription to reduce latency.
+A *track bundle* is a collection of tracks intended to be delivered together.
+Objects within a track bundle may be prioritized relative to each other via the delivery order property.
+This allows objects to be prioritized within a track (ex. newer > older) and between tracks (ex. audio > video).
+The track bundle may contain a catalog indicating the available tracks.
 
-*A WebTransport session* is established for each Warp broadcast. The client issues a CONNECT request with a URL to the server. The server parses the URL based on the application, using it to identify the broadcast and authorize the user. Multiple broadcasts require multiple WebTransport sessions, which can be pooled over a single QUIC connection for efficiency.
+A WebTransport *session* is established for each track bundle.
+The client issues a CONNECT request with a URL which the server uses for identification and authentication.
+All control messages and prioritization occur within the context of a single WebTransport session, which means a single track bundle.
+Multiple WebTransport sessions may be pooled over a single QUIC connection for efficiency.
 
 
 # Motivation
@@ -328,15 +334,15 @@ WebTransport can currently operate via HTTP/3 and HTTP/2, using QUIC or TCP unde
 As mentioned in the motivation ({{motivation}}) section, TCP introduces head-of-line blocking and will result in a worse experience.
 It is RECOMMENDED to use WebTransport over HTTP/3.
 
-### CONNECT request
-The server uses the HTTP CONNECT request to identify client and the requested broadcast.
+### CONNECT
+The server uses the HTTP CONNECT request to identify client and the requested track bundle.
 The application dictates how this information is encoded into the request.
-For example, an authentication token and broadcast ID could be included in the path.
+For example, a broadcast ID and authentication token could be included in the path.
 
 The server MAY return an error status code for any reason. Examples include:
-* "400 Bad Request" when the broadcast and/or authorization cannot be parsed.
+* "400 Bad Request" when the request cannot be parsed.
 * "401 Unauthorized" when the client cannot be identified.
-* "403 Forbidden" when the client is unauthorized to access the specified broadcast.
+* "403 Forbidden" when the client is unauthorized to access the specified resource.
 * "404 Not Found" when the broadcast cannot be identified.
 * "307 Temporary Redirect" when the client should be served at a different url.
 

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -344,7 +344,6 @@ The server MAY return an error status code for any reason. Examples include:
 * "401 Unauthorized" when the client cannot be identified.
 * "403 Forbidden" when the client is unauthorized to access the specified resource.
 * "404 Not Found" when the broadcast cannot be identified.
-* "307 Temporary Redirect" when the client should be served at a different url.
 
 Otherwise the server MUST respond with a "200 OK" to establish the WebTransport session.
 

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -343,7 +343,7 @@ It is RECOMMENDED to use WebTransport over HTTP/3.
 ### CONNECT
 The server uses the HTTP CONNECT request for identification and authorization of a track bundle.
 The specific mechanism is left up to the application.
-For example, a broadcast ID and authentication token could be included in the path.
+For example, an identifier and authentication token could be included in the path.
 
 The server MAY return an error status code for any reason, for example a 403 when the client is forbidden.
 Otherwise the server MUST respond with a "200 OK" to establish the WebTransport session.
@@ -565,7 +565,7 @@ Track Descriptor {
 {: #warp-track-descriptor title="Warp Track Descriptor"}
 
 * Track ID:
-A unique identifier for the track
+A unique identifier for the track within the track bundle.
 
 * Container Format:
 The container format as defined in {{containers}}.

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -191,6 +191,12 @@ The client issues a CONNECT request with a URL which the server uses for identif
 All control messages and prioritization occur within the context of a single WebTransport session, which means a single track bundle.
 Multiple WebTransport sessions may be pooled over a single QUIC connection for efficiency.
 
+As an example, consider a scenario where `example.org` hosts a simple live stream that anyone can subscribe to.
+That live stream would be a single track bundle, accessible via the WebTransport URL: `https://example.org/livestream`.
+In the simple scenario, the track bundle would contain only two media tracks, one with audio and one with video.
+In more complicated scenarios, it could provide multiple video formats of different levels of video quality; those tracks would be variants of each other.
+Note that the track IDs are opaque on the Warp level; if the player has not received the description of media tracks out of band in advance, it would have to request the broadcast description first.
+
 
 # Motivation
 
@@ -335,7 +341,7 @@ As mentioned in the motivation ({{motivation}}) section, TCP introduces head-of-
 It is RECOMMENDED to use WebTransport over HTTP/3.
 
 ### CONNECT
-The server uses the HTTP CONNECT request to identify client and the requested track bundle.
+The server uses the HTTP CONNECT request to identify the client and the requested track bundle.
 The application dictates how this information is encoded into the request.
 For example, a broadcast ID and authentication token could be included in the path.
 

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -318,8 +318,8 @@ Objects are NOT REQUIRED to be aligned and the decoder MUST be prepared to skip 
 A connection is established using WebTransport {{WebTransport}}.
 
 To summarize:
-The client issues a HTTP CONNECT request with the intention of establishing a new WebTransport session.
-The server returns an OK response if the WebTransport session has been established, or an error otherwise.
+The client issues a HTTP CONNECT request to a URL.
+The server returns an "200 OK" response to establish the WebTransport session, or an error status code otherwise.
 
 A WebTransport session exposes the basic QUIC service abstractions.
 Specifically, either endpoint may create independent streams which are reliably delivered in order until canceled.
@@ -333,7 +333,13 @@ The server uses the HTTP CONNECT request to identify client and the requested br
 The application dictates how this information is encoded into the request.
 For example, an authentication token and broadcast ID could be included in the path.
 
-The server MAY return an error status code for any reason, such as a "403 Forbidden" when unauthorized.
+The server MAY return an error status code for any reason. Examples include:
+* "400 Bad Request" when the broadcast and/or authorization cannot be parsed.
+* "401 Unauthorized" when the client cannot be identified.
+* "403 Forbidden" when the client is unauthorized to access the specified broadcast.
+* "404 Not Found" when the broadcast cannot be identified.
+* "307 Temporary Redirect" when the client should be served at a different url.
+
 Otherwise the server MUST respond with a "200 OK" to establish the WebTransport session.
 
 ## Streams

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -184,7 +184,7 @@ The basic element of Warp is *a media object*. A media object is a single addres
 A *track bundle* is a collection of tracks intended to be delivered together.
 Objects within a track bundle may be prioritized relative to each other via the delivery order property.
 This allows objects to be prioritized within a track (ex. newer > older) and between tracks (ex. audio > video).
-The track bundle may contain a catalog indicating the available tracks.
+The track bundle contains a catalog indicating the available tracks.
 
 A WebTransport *session* is established for each track bundle.
 The client issues a CONNECT request with a URL which the server uses for identification and authentication.
@@ -193,9 +193,9 @@ Multiple WebTransport sessions may be pooled over a single QUIC connection for e
 
 As an example, consider a scenario where `example.org` hosts a simple live stream that anyone can subscribe to.
 That live stream would be a single track bundle, accessible via the WebTransport URL: `https://example.org/livestream`.
-In the simple scenario, the track bundle would contain only two media tracks, one with audio and one with video.
-In more complicated scenarios, it could provide multiple video formats of different levels of video quality; those tracks would be variants of each other.
-Note that the track IDs are opaque on the Warp level; if the player has not received the description of media tracks out of band in advance, it would have to request the broadcast description first.
+In a simple scenario, the track bundle would contain only two media tracks, one with audio and one with video.
+In a more complicated scenario, the track bundle could multiple tracks with different formats, encodings, bitrates, and quality levels, possibly for the same content.
+The receiver learns about each available track within the bundle via the catalog, and can choose to subscribe to a subset.
 
 
 # Motivation

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -341,16 +341,11 @@ As mentioned in the motivation ({{motivation}}) section, TCP introduces head-of-
 It is RECOMMENDED to use WebTransport over HTTP/3.
 
 ### CONNECT
-The server uses the HTTP CONNECT request to identify the client and the requested track bundle.
-The application dictates how this information is encoded into the request.
+The server uses the HTTP CONNECT request for identification and authorization of a track bundle.
+The specific mechanism is left up to the application.
 For example, a broadcast ID and authentication token could be included in the path.
 
-The server MAY return an error status code for any reason. Examples include:
-* "400 Bad Request" when the request cannot be parsed.
-* "401 Unauthorized" when the client cannot be identified.
-* "403 Forbidden" when the client is unauthorized to access the specified resource.
-* "404 Not Found" when the broadcast cannot be identified.
-
+The server MAY return an error status code for any reason, for example a 403 when the client is forbidden.
 Otherwise the server MUST respond with a "200 OK" to establish the WebTransport session.
 
 ## Streams
@@ -542,6 +537,7 @@ This is a media bitstream intended for the decoder and SHOULD NOT be processed b
 
 ## CATALOG {#message-catalog}
 The sender advertises tracks via the CATALOG message.
+The receiver can then SUBSCRIBE to the indiciated tracks by ID.
 
 The format of the CATALOG message is as follows:
 
@@ -554,7 +550,7 @@ CATALOG Message {
 {: #warp-catalog-format title="Warp CATALOG Message"}
 
 * Track Count:
-The number of tracks.
+The number of tracks within the catalog.
 
 
 For each track, there is a track descriptor with the format:

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -319,7 +319,7 @@ A connection is established using WebTransport {{WebTransport}}.
 
 To summarize:
 The client issues a HTTP CONNECT request with the intention of establishing a new WebTransport session.
-The server returns an 200 OK response if the WebTransport session has been established, or an error status otherwise.
+The server returns an OK response if the WebTransport session has been established, or an error otherwise.
 
 A WebTransport session exposes the basic QUIC service abstractions.
 Specifically, either endpoint may create independent streams which are reliably delivered in order until canceled.
@@ -328,12 +328,13 @@ WebTransport can currently operate via HTTP/3 and HTTP/2, using QUIC or TCP unde
 As mentioned in the motivation ({{motivation}}) section, TCP introduces head-of-line blocking and will result in a worse experience.
 It is RECOMMENDED to use WebTransport over HTTP/3.
 
-## Authentication
-The application SHOULD use the WebTransport CONNECT request for authentication.
-For example, including an authentication token in the path.
+### CONNECT request
+The server uses the HTTP CONNECT request to identify client and the requested broadcast.
+The application dictates how this information is encoded into the request.
+For example, an authentication token and broadcast ID could be included in the path.
 
-An endpoint SHOULD terminate the connection with an error ({{termination}}) if the peer attempts an unauthorized action.
-For example, attempting to use a different role than pre-negotated ({{role}}).
+The server MAY return an error status code for any reason, such as a "403 Forbidden" when unauthorized.
+Otherwise the server MUST respond with a "200 OK" to establish the WebTransport session.
 
 ## Streams
 Warp endpoints communicate over QUIC streams. Every stream is a sequence of messages, framed as described in {{messages}}.


### PR DESCRIPTION
There's quite a few benefits for such a minor change:

* broadcast selection is now explicitly authorized
* prioritization works at the WebTransport level
* OBJECT headers are much smaller.
* CATALOG messages are simpler (too simple).
* OBJECT messages no longer need to be rewritten.
* Only one control stream is needed. (TODO)
* Generic clients work via a single URL now.

See the mailing list for more in-depth rationale.