### PR TITLE
IETF 116:  Update Subscribe Messages

### DIFF
--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -169,11 +169,6 @@ Track Name:
 
 : See {{track-name}}.
 
-Track ID:
-
-: An hop-by-hop variable length integer for a Track Name that is carried in Object message header. Track ID is setup
-as part of Publish/Subscribe control message exchanges. See {{message-subscribe-reply}}
-
 Provider: 
 
 : Entity capable of hosting media application
@@ -678,9 +673,12 @@ The `TRACK INFO` structure is as defined below
 ~~~
 TRACK INFO {
   Track Name Length(i),
-  Track Name(...)...,
+  Track Name(...),
+  Track ID (i),
   Track Authorization Info Length(i),
-  Track Authorization Info (...)...
+  Track Authorization Info (...),
+  [Group Sequence (i)],
+  [Object Sequence (i)]
 }
 ~~~
 {: #warp-track-info-format title="Warp TRACK INFO Content"}
@@ -688,6 +686,16 @@ TRACK INFO {
 
 * Track Name:
 Identifies the fully qualified track name as defined in ({{model-track}}).
+
+* Track ID: 
+A proposal serving as short hop-by-hop identifier to be used in the OBJECT ({{message-object}}) message header for the requested tack. Given that the media corresponding to a track can potentially be delivered over multiple data streams, the Track ID provides the necessary mapping between the "Track Name" in the control message and the corresponding data streams. It also serves as a compression identifier for containing the size of object headers instead of carrying complete "Track Name" information in every object message. A client MUST choose an Track ID value that is unique within a QUIC Connection.
+
+* Group Sequence: 
+Identifies the group within the track to start delivering the objects. This field is optional and when omitted, the publisher MUST deliver the objects from the most recent group.
+
+* Object Sequence: 
+Identifies the object within the track to start the media delivery. The `Group Sequence` field MUST be set to identify the group under which to
+the deliver the objects. This field is optional and when omitted, the publisher MUST deliver starting from the beginning of the selected group.
 
 * Track Authorization Info: 
 Carries track authorization, typically in the form of a token, authorizing the client’s subscription to the track. The specifics of obtaining the authorization information is out of scope for this specification.
@@ -700,8 +708,6 @@ Subscriptions stay active until one of the following happens:
 
 On successful subscription, the publisher MUST deliver objects
 from the beginnig of the most recent group in the track, i.e, starting at Object Sequence of 0.
-
-A client MUST renew its subscriptions by sending a new `SUBSCRIBE` to keep them active. Such subscriptions MUST refresh the existing subscriptions and thus only the most recent SUBSCRIBE message is considered active. A renewal period of 5 seconds is RECOMMENDED.
 
 ## SUBSCRIBE REPLY {#message-subscribe-reply}
 
@@ -744,11 +750,12 @@ Identifies the track in the request message for which this
 response is provided.
 
 * Response:
-Provides result of the transaction, where a value of `Ok` indicates successful subscription. For failed response, the "Reason Phrase" is populated with appropriate reason code.
+Provides result of the transaction, where a value of `Ok` indicates successful subscription. For failed response, the "Reason Phrase" 
+is populated with appropriate reason.
+
 
 * Track ID:
-A short hop-by-hop identifier to be used in the OBJECT ({{message-object}}) message header for the requested tack. Given that the media corresponding to a track can potentially be delivered over multiple data streams, the `Track ID` provides the necessary mapping between the "Track Name" in the control message and the corresponding data streams. It also serves as a compression identifier for containing the size of object headers instead of carrying complete "Track Name" information in every object message. The `Track ID` chosen MUST be unique within the QUIC Connection and is populated for successful subscriptions.
-
+Identifies the hop-by-hop identifier mapping the given Track Name to be populated in the Object messages ({{message-object}}) and MUST only be present if the `Response` is `Ok`. This field is populated with either the `Track ID` value provided in the request or the one chosen by client processing the request. The Track ID field in the Object's header messages MUST be populated with the value in this field. 
 
 ## GOAWAY {#message-goaway}
 The `GOAWAY` message is sent by the server to force the client to reconnect.

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -741,7 +741,7 @@ SUBSCRIBE REQUEST Message {
 
 
 * Track URI:
-Identifies the track as defined in ({{model-track}}).
+Identifies the track as defined in ({{track-uri}}).
 
 * Track ID: 
 Session specific identifier that maps the Track URI to the Track ID in OBJECT ({{message-object}}) message headers for the advertised track. Peer processing the request message MAY end up choosing a different Track ID (see {{message-subscribe-ok}}). Track IDs are generally shorter than Track URIs and thus reduce the overhead in OBJECT messages.

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -805,8 +805,8 @@ enum Track Result
 }
 
 TRACK RESPONSE {
-  Track Name Length(i),
-  Track Name(...)...,
+  Track URI Length(i),
+  Track URI(...),
   Track Result Response,
   [Track ID(i)],
   [ Reason Phrase Length (i) ],
@@ -816,7 +816,7 @@ TRACK RESPONSE {
 {: #warp-track-response-format title="Warp TRACK RESPONSE Content"}
 
 
-* Track Name:
+* Track URI:
 Identifies the track in the request message for which this
 response is provided.
 

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -908,6 +908,7 @@ TODO: fill out currently missing registries:
 * Warp version numbers
 * SETUP parameters
 * Track Request parameters
+* Subscribe Error codes
 * Track format numbers
 * Message types
 * Object headers

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -847,7 +847,7 @@ The client MUST send a ROLE parameter with one of the three values specified abo
 
 # Track Request Parameters {#track-req-params}
 
-The Track Request Parameters identify properties of the track requesting in either the PUBLISH REQUEST or SUSBCRIBE REQUEST control messages. Every parameter MUST appear at most once. The peers MUST close the connection if there are duplicates. The Parameter Value Length field indicates the length of the Parameter Value.
+The Track Request Parameters identify properties of the track requested in either the PUBLISH REQUEST or SUSBCRIBE REQUEST control messages. Every parameter MUST appear at most once. The peers MUST close the connection if there are duplicates. The Parameter Value Length field indicates the length of the Parameter Value.
 
 ### GROUP SEQUENCE Parameter
 

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -605,7 +605,7 @@ OBJECT Message {
 {: #warp-object-format title="Warp OBJECT Message"}
 
 * Track ID:
-The track identifier as declared in CATALOG ({{message-catalog}}).
+The track identifier obtained as part of subscription and/or publish control message exchanges.
 
 * Group Sequence :
 An integer always starts at 0 and increases sequentially at the original media publisher.
@@ -711,7 +711,7 @@ the objects. This field is optional and when omitted, the
 publisher MUST deliver the objects from the most recent 
 group.
 
-* Object ID:
+* Object Sequence:
 Identifies the object within the track to start the media 
 delivery. The group MUST either match the `Group Sequence` if provided
 or MUST be the most recent group. This field is optional and 

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -169,6 +169,11 @@ Track Name:
 
 : See {{track-name}}.
 
+Track ID:
+
+: An hop-by-hop variable length integer for a Track Name that is carried in Object message header. Track ID is setup
+as part of Publish/Subscribe control message exchanges. See {{message-subscribe-reply}}
+
 Provider: 
 
 : Entity capable of hosting media application
@@ -654,13 +659,12 @@ A future draft will add the ability to add/remove/update tracks.
 
 ## SUBSCRIBE REQUEST {#message-subscribe-req}
 
-Entities that intend to receive media will do so via subscriptions to
-one or more tracks. The information for the tracks can be obtained via catalog or from incoming SUBSCRIBE messages.
+Entities that intend to receive media will do so via subscriptions to one or more tracks. The information for the tracks can be obtained via catalog or from incoming SUBSCRIBE REQUEST messages.
 
 The format of SUBSCRIBE is as follows:
 
 ~~~
-SUBSCRIBE Message {
+SUBSCRIBE REQUEST Message {
   TRACK INFO Track
 }
 ~~~
@@ -675,11 +679,8 @@ The `TRACK INFO` structure is as defined below
 TRACK INFO {
   Track Name Length(i),
   Track Name(...)...,
-  Track ID (i),
   Track Authorization Info Length(i),
   Track Authorization Info (...)...
-  [Group Sequence (i)],
-  [Object Sequence (i)],
 }
 ~~~
 {: #warp-track-info-format title="Warp TRACK INFO Content"}
@@ -688,30 +689,17 @@ TRACK INFO {
 * Track Name:
 Identifies the fully qualified track name as defined in ({{model-track}}).
 
-* Track ID:
-A proposal serving as short hop-by-hop identifier to be used in the OBJECT ({{message-object}}) message header for the requested tack. Given that the media corresponding to a track can potentially be delivered over multiple data streams, the `Track ID` provides the necessary mapping between the "Track Name" in the control message and the corresponding data streams. It also serves as a compression identifier for containing the size of object headers instead of carrying complete "Track Name" information in every object message. A client MUST choose an `Track ID` value that is unique within a QUIC Connection.
-
-* Group Sequence:
-Identifies the group within the track to start delivering 
-the objects. This field is optional and when omitted, the
-publisher MUST deliver the objects from the most recent 
-group.
-
-* Object Sequence:
-Identifies the object within the track to start the media 
-delivery. The group MUST either match the `Group Sequence` if provided
-or MUST be the most recent group. This field is optional and 
-when omitted, the publisher MUST deliver starting from the 
-beginning of the selected group, i.e., starting at Object Sequence of 0.
-
 * Track Authorization Info: 
-Carries track authorization, typically in the form of a token, authorizing client’s subscription to the track. The specifics of obtaining the authorization information is out of scope for this specification.
+Carries track authorization, typically in the form of a token, authorizing the client’s subscription to the track. The specifics of obtaining the authorization information is out of scope for this specification.
 
 Subscriptions stay active until one of the following happens:
 
 - a client local policy dictates expiration of a subscription.
 - optionally, a server policy dicates subscription expiration.
 - the underlying transport is disconnected.
+
+On successful subscription, the publisher MUST deliver objects
+from the beginnig of the most recent group in the track, i.e, starting at Object Sequence of 0.
 
 A client MUST renew its subscriptions by sending a new `SUBSCRIBE` to keep them active. Such subscriptions MUST refresh the existing subscriptions and thus only the most recent SUBSCRIBE message is considered active. A renewal period of 5 seconds is RECOMMENDED.
 
@@ -736,17 +724,16 @@ The `TRACK RESPONSE` structure is as defined below
 enum Track Result
 {
   Ok(0),
-  Expired(1),
-  Fail(2)
+  Fail(1)
 }
 
 TRACK RESPONSE {
   Track Name Length(i),
   Track Name(...)...,
   Track Result Response,
+  [Track ID(i)],
   [ Reason Phrase Length (i) ],
   [ Reason Phrase (...) ],
-  [ Track ID(i) ]
 }
 ~~~
 {: #warp-track-response-format title="Warp TRACK RESPONSE Content"}
@@ -757,11 +744,10 @@ Identifies the track in the request message for which this
 response is provided.
 
 * Response:
-Provides result of the transaction, where a value of `Ok` indicates successful subscription. For failed or expired responses, the "Reason Phrase" shall be populated with appropriate reason code.
+Provides result of the transaction, where a value of `Ok` indicates successful subscription. For failed response, the "Reason Phrase" is populated with appropriate reason code.
 
 * Track ID:
-Identifies the hop-by-hop identifier mapping the given Track Name to be populated in the Object messages ({{message-object}}). This field is optional and is provided in cases where the end point is unable to use the `Track ID` proposed by the peer in the request message. If populated, the `Track ID` field in the Object's header messages MUST be populated with the value in this field otherwise the `Track ID` value MUST correspond to one in the request message for a given track.
-
+A short hop-by-hop identifier to be used in the OBJECT ({{message-object}}) message header for the requested tack. Given that the media corresponding to a track can potentially be delivered over multiple data streams, the `Track ID` provides the necessary mapping between the "Track Name" in the control message and the corresponding data streams. It also serves as a compression identifier for containing the size of object headers instead of carrying complete "Track Name" information in every object message. The `Track ID` chosen MUST be unique within the QUIC Connection and is populated for successful subscriptions.
 
 
 ## GOAWAY {#message-goaway}

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -57,7 +57,7 @@ informative:
     date: 2020-03
   NewReno: RFC6582
   BBR: I-D.cardwell-iccrg-bbr-congestion-control-02
-  
+
 --- abstract
 
 This document defines the core behavior for Warp, a live media transport protocol over QUIC.
@@ -858,7 +858,7 @@ The GROUP SEQUENCE parameter (key 0x00) identifies the group within the track to
 The OBJECT SEQUENCE parameter (key 0x01) identifies the object with the track to start delivering the media. The `GROUP SEQUENCE` parameter MUST be set to identify the group under which to start the media delivery. The publisher MUST start delivering from the beginning of the selected group when this parameter is omitted.
 
 ### AUTHORIZATION INFO Parameter
-AUTHORIZATION INFO parameter (key 0x02) identifies the mandatory parameter carrying track's authorization, authorizing the client’s subscription to the track. The specifics of obtaining the authorization information is out of scope for this specification.
+AUTHORIZATION INFO parameter (key 0x02) identifies track's authorization information. This parameter is populated for cases where the authorization is required at the track level.
 
 # Containers
 The container format describes how the underlying codec bitstream is encoded.

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -612,9 +612,9 @@ A length of 0 indicates the message is unbounded and continues until the end of 
 |------|----------------------------------------------|
 | 0x3  | SUBSCRIBE REQUEST ({{message-subscribe-req}})|
 |------|----------------------------------------------|
-| 0x4  | SUBSCRIBE OK ({{message-subscribe-ok}})      |
+| 0x5  | SUBSCRIBE OK ({{message-subscribe-ok}})      |
 |------|----------------------------------------------|
-| 0x4  | SUBSCRIBE ERROR ({{message-subscribe-error}})|
+| 0x6  | SUBSCRIBE ERROR ({{message-subscribe-error}})|
 |------|----------------------------------------------|
 | 0x10 | GOAWAY ({{message-goaway}})                  |
 |------|----------------------------------------------|

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -612,9 +612,9 @@ A length of 0 indicates the message is unbounded and continues until the end of 
 |------|----------------------------------------------|
 | 0x3  | SUBSCRIBE REQUEST ({{message-subscribe-req}})|
 |------|----------------------------------------------|
-| 0x5  | SUBSCRIBE OK ({{message-subscribe-ok}})      |
+| 0x4  | SUBSCRIBE OK ({{message-subscribe-ok}})      |
 |------|----------------------------------------------|
-| 0x6  | SUBSCRIBE ERROR ({{message-subscribe-error}})|
+| 0x5  | SUBSCRIBE ERROR ({{message-subscribe-error}})|
 |------|----------------------------------------------|
 | 0x10 | GOAWAY ({{message-goaway}})                  |
 |------|----------------------------------------------|
@@ -737,31 +737,31 @@ Entities that intend to receive media will do so via subscriptions to one or mor
 The format of SUBSCRIBE REQUEST is as follows:
 
 ~~~
-TrackInfo Parameter {
-  TrackInfo Parameter ID (i),
-  TrackInfo Parameter Length (i),
-  TrackInfo Parameter Value (..),
+Track Parameter {
+  Track Parameter ID (i),
+  Track Parameter Length (i),
+  Track Parameter Value (..),
 }
 
 SUBSCRIBE REQUEST Message {
   Track URI Length(i),
   Track URI(...),
   Track ID (i),
-  TrackInfo Parameters (..) ...
+  Track Parameters (..) ...
 }
 ~~~
 {: #warp-subscribe-format title="Warp SUBSCRIBE REQUEST Message"}
 
 
 * Track URI:
-Identifies the fully qualified track name as defined in ({{model-track}}).
+Identifies the track as defined in ({{model-track}}).
 
 * Track ID: 
-An session specific identifier used in OBJECT ({{message-object}}) message headers for the requested track. Given that the media corresponding to a track can potentially be delivered over multiple data streams, the Track ID maps the Track URI in the control message to the corresponding data streams. Track IDs are generally shorter than Track URIs and thus reduce the overhead in OBJECT messages.
+Session specific identifier that maps the Track URI to the Track ID in OBJECT ({{message-object}}) message headers for the advertised track. Peer processing the request message MAY end up choosing a different Track ID (see {{message-subscribe-ok}}). Track IDs are generally shorter than Track URIs and thus reduce the overhead in OBJECT messages.
 
 TrackInfo Parameters are defined in {{track-params}}.
 
-On successful subscription, the publisher MUST deliver objects
+On successful subscription, the publisher SHOULD start delivering objects
 from the group sequence and object sequence as defined in {{track-params}}.
 
 ## SUBSCRIBE OK {#message-subscribe-ok}
@@ -774,7 +774,7 @@ SUBSCRIBE OK
   Track URI Length(i),
   Track URI(...),
   Track ID(i),
-  Expires (i),
+  Expires (i)
 }
 ~~~
 {: #warp-subscribe-ok format title="Warp SUBSCRIBE OK Message"}
@@ -784,7 +784,7 @@ Identifies the track in the request message for which this
 response is provided.
 
 * Track ID:
-Maps the Track URI. This field is populated with either the `Track ID` value provided in the request or the one chosen by the peer processing the request. The Track ID field in the OBJECT's header messages MUST be populated with the value in this field. 
+Maps the Track URI. This field is populated with either the Track ID value provided in the request or the one chosen by the peer processing the request. The Track ID field in the OBJECT ({{message-object}}) message headers MUST be populated with the value in this field. 
 
 * Expires:
 Time in milliseconds after which the subscription is no longer valid.
@@ -812,7 +812,7 @@ Identifies the track in the request message for which this
 response is provided.
 
 * Reason Phrase:
-Provides the reason for subscription error and `Reason Phrase Length` carries its length.
+Provides the reason for subscription error and Reason Phrase Length field carries its length.
 
 
 ## GOAWAY {#message-goaway}
@@ -859,19 +859,18 @@ The ROLE parameter (key 0x00) allows the client to specify what roles it expects
 
 The client MUST send a ROLE parameter with one of the three values specified above. The server MUST close the connection if the ROLE parameter is missing, is not one of the three above-specified values, or it is different from what the server expects based on the application in question.
 
-# TrackInfo Parameters {#track-params}
+# Track Parameters {#track-params}
 
-The TrackInfo parameters are described as below. Every parameter MUST appear at most once. The peers SHOULD verify that and close the connection if a parameter appears more than once.
-The Parameter Value Length field indicates the length of the Parameter Value.
+The Track parameters are described as below. Every parameter MUST appear at most once. The peers SHOULD verify that and close the connection if a parameter appears more than once. The Parameter Value Length field indicates the length of the Parameter Value.
 
 ### GROUP SEQUENCE Parameter
 
-The GROUP SEQUENCE parameter (key 0x00) identifies the group within the track to start delivering the objects. The publisher MUST deliver the objects from the most recent group, when this parameter is omitted.
+The GROUP SEQUENCE parameter (key 0x00) identifies the group within the track to start delivering the objects. The publisher MUST start delivering the objects from the most recent group, when this parameter is omitted.
 
-### OBJECT SEQUENCE 
-The OBJECT SEQUENCE parameter (key 0x01) identifies the object within the track to start the media delivery. The `GROUP SEQUENCE` parameter MUST be set to identify the group under which to the deliver the objects. The publisher MUST deliver from the beginning of the selected group when this parameter is omitted.
+### OBJECT SEQUENCE Parameter
+The OBJECT SEQUENCE parameter (key 0x01) identifies the object with the track to start delivering the media. The `GROUP SEQUENCE` parameter MUST be set to identify the group under which to start the media delivery. The publisher MUST start delivering from the beginning of the selected group when this parameter is omitted.
 
-### AUTHORIZATION INFO
+### AUTHORIZATION INFO Parameter
 AUTHORIZATION INFO parameter (key 0x02) identifies the mandatory parameter carrying track's authorization, authorizing the client’s subscription to the track. The specifics of obtaining the authorization information is out of scope for this specification.
 
 # Containers

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -725,32 +725,29 @@ Entities that intend to receive media will do so via subscriptions to one or mor
 The format of SUBSCRIBE REQUEST is as follows:
 
 ~~~
-Track Parameter {
-  Track Parameter ID (i),
-  Track Parameter Length (i),
-  Track Parameter Value (..),
+Track Request Parameter {
+  Track Request Parameter Key (i),
+  Track Request Parameter Length (i),
+  Track Request Parameter Value (..),
 }
 
 SUBSCRIBE REQUEST Message {
-  Track URI Length(i),
-  Track URI(...),
-  Track ID (i),
-  Track Parameters (..) ...
+  Full Track Name Length(i),
+  Full Track Name(...),
+  Track Request Parameters (..) ...
 }
 ~~~
 {: #warp-subscribe-format title="Warp SUBSCRIBE REQUEST Message"}
 
 
-* Track URI:
-Identifies the track as defined in ({{track-uri}}).
+* Full Track Name:
+Identifies the track as defined in ({{track-fn}}).
 
-* Track ID: 
-Session specific identifier that maps the Track URI to the Track ID in OBJECT ({{message-object}}) message headers for the advertised track. Peer processing the request message MAY end up choosing a different Track ID (see {{message-subscribe-ok}}). Track IDs are generally shorter than Track URIs and thus reduce the overhead in OBJECT messages.
-
-TrackInfo Parameters are defined in {{track-params}}.
+* Track Request Parameters:
+ As defined in {{track-req-params}}.
 
 On successful subscription, the publisher SHOULD start delivering objects
-from the group sequence and object sequence as defined in {{track-params}}.
+from the group sequence and object sequence as defined in the `Track Request Parameters`.
 
 ## SUBSCRIBE OK {#message-subscribe-ok}
 
@@ -759,26 +756,23 @@ A `SUBSCRIBE OK` control message is sent for successful subscriptions.
 ~~~
 SUBSCRIBE OK
 {
-  Track URI Length(i),
-  Track URI(...),
+  Full Track Name Length(i),
+  Full Track Name(...),
   Track ID(i),
   Expires (i)
 }
 ~~~
 {: #warp-subscribe-ok format title="Warp SUBSCRIBE OK Message"}
 
-* Track URI:
+* Full Track Name:
 Identifies the track in the request message for which this
 response is provided.
 
-* Track ID:
-Maps the Track URI. This field is populated with either the Track ID value provided in the request or the one chosen by the peer processing the request. The Track ID field in the OBJECT ({{message-object}}) message headers MUST be populated with the value in this field. 
+* Track ID: 
+Session specific identifier that maps the Full Track Name to the Track ID in OBJECT ({{message-object}}) message headers for the advertised track. Track IDs are generally shorter than Full Track Names and thus reduce the overhead in OBJECT messages. 
 
 * Expires:
-Time in milliseconds after which the subscription is no longer valid.
-
-Subscriptions stay active until it expires or the underlying transport is disconnected.
-
+Time in milliseconds after which the subscription is no longer valid. A value of 0 implies that the subscription stays active until its explicitly unsubscribed or the underlying transport is disconnected.
 
 ## SUBSCRIBE ERROR {#message-subscribe-error}
 
@@ -787,20 +781,24 @@ A `SUBSCRIBE ERROR` control message is sent for unsuccessful subscriptions.
 ~~~
 SUBSCRIBE ERROR
 {
-  Track URI Length(i),
-  Track URI(...),
+  Full Track Name Length(i),
+  Full Track Name(...),
+  Error Code (i),
   Reason Phrase Length (i),
   Reason Phrase (...),
 }
 ~~~
 {: #warp-subscribe-error format title="Warp SUBSCRIBE ERROR Message"}
 
-* Track URI:
+* Full Track Name:
 Identifies the track in the request message for which this
 response is provided.
 
+* Error Code:
+Identifies an integer error code for subscription failure.
+
 * Reason Phrase:
-Provides the reason for subscription error and Reason Phrase Length field carries its length.
+Provides the reason for subscription error and `Reason Phrase Length` field carries its length.
 
 
 ## GOAWAY {#message-goaway}
@@ -847,9 +845,9 @@ The ROLE parameter (key 0x00) allows the client to specify what roles it expects
 
 The client MUST send a ROLE parameter with one of the three values specified above. The server MUST close the connection if the ROLE parameter is missing, is not one of the three above-specified values, or it is different from what the server expects based on the application in question.
 
-# Track Parameters {#track-params}
+# Track Request Parameters {#track-req-params}
 
-The Track parameters are described as below. Every parameter MUST appear at most once. The peers SHOULD verify that and close the connection if a parameter appears more than once. The Parameter Value Length field indicates the length of the Parameter Value.
+The Track Request Parameters identify properties of the track requesting in either the PUBLISH REQUEST or SUSBCRIBE REQUEST control messages. Every parameter MUST appear at most once. The peers MUST close the connection if there are duplicates. The Parameter Value Length field indicates the length of the Parameter Value.
 
 ### GROUP SEQUENCE Parameter
 
@@ -909,6 +907,7 @@ The producer and consumer MUST cancel a stream, preferably the lowest priority, 
 TODO: fill out currently missing registries:
 * Warp version numbers
 * SETUP parameters
+* Track Request parameters
 * Track format numbers
 * Message types
 * Object headers


### PR DESCRIPTION
This PR depends on #121 and has the following changes  to capture IETF 116 decisions 

1. Rename subscribe message to subscribe request 
2. Include track names and authorization in the subscribe request
3. Add  basic support for subscribe reply providing the results of subscription
4. Add support for short compression identifiers as Track Id (varint) to be used in the object header messages

Currently the subscribe granularity is per track and a future PR can be modified to support multiple tracks if needed.