### PR TITLE
IETF116: Relay behavior Support

### DIFF
--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -676,7 +676,7 @@ OBJECT Message {
 {: #warp-object-format title="Warp OBJECT Message"}
 
 * Track ID:
-The track identifier as declared in CATALOG ({{message-catalog}}).
+The track identifier obtained as part of subscription and/or publish control message exchanges.
 
 * Group Sequence :
 An integer always starts at 0 and increases sequentially at the original media publisher.


### PR DESCRIPTION
This PR depends on #121 , #122 and #123  and adds starter text to describe protocol behavior for dealing with publishes and subscribes.

Future PR will add details on congestion response in general and for relays in particular.