### PR TITLE
IETF116: Fill in Relay Publish Interaction Sub-Section

### DIFF
--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -599,15 +599,15 @@ Relays MAY aggregate subscriptions for a given track when multiple subscribers r
 
 ## Publisher Interactions
 
-Publishing through the relay starts with publisher sending "ANNOUNCE" control message for the set of tracks, identified via their Full Track Names ({{model-track}}). Relays MUST ensure that publishers are authorized by:
+Publishing through the relay starts with publisher sending "ANNOUNCE" control message with a `Track Namespace` ({{model-track}}).
 
-- Verifying that the publisher is authorized to publish the content associated with the "Full Track Name". The authorization information can be part of annoucement themselves or part of the encompassing session. Specifics of the authorization process depends on the way the relay is managed and is typically based on prior business agreement with the Origin, for example.
+Relays MUST ensure that publishers are authorized by:
+
+- Verifying that the publisher is authorized to publish the content associated with the set of tracks whose Full Track Name share a common prefix with the announced namespace. Specifics of where the authorization happens, either at the relays or forwarded for further processing, depends on the way the relay is managed and is application specific (typically based on prior business agreement). If forwarded, the authorization information from the original annouce control message MUST be identical.
 
 Relays respond with "ANNOUNCE OK" and/or "ANNONCE ERROR" control messages providing the results of announcement.
 
-OBJECT message header carry short hop-by-hop `Track Id` that maps to the "Full Track Name". Relays MUST use the `Track Id` in the incoming OBJECT messages to find active subscribers with track information matching the `Track Id`. Relays MUST NOT depend on OBJECT payload content for making forwarding decisions and MUST only depend on the fields, such as priority order and other metadata properties in the OBJECT message header. Unless determined by congestion response, Relays MUST forward the OBJECT message to the matching subscribers. 
-
-__Note to authors: This above send behavior is common across all senders and once we have a sufficient text defined elsewhere, we can just refer to the appropriate section.__
+OBJECT message header carry short hop-by-hop Track Id that maps to the Full Track Name (see {{message-subscribe-ok}}). Relays use the Track ID of an incoming OBJECT message to identify its track and find the active subscribers for that track. Relays MUST NOT depend on OBJECT payload content for making forwarding decisions and MUST only depend on the fields, such as priority order and other metadata properties in the OBJECT message header. Unless determined by congestion response, Relays MUST forward the OBJECT message to the matching subscribers. 
 
 ## Relay Discovery and Failover
 

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -615,11 +615,18 @@ Relays make such forwarding and/or caching decisions, based on match of the iden
 
 
 ## Publisher Interactions
-Publishers MAY be configured to publish the objects to a Relays based on the application configuration and topology.  Publishing set of tracks through the Relay starts with a "PUBLISH" control messages that identifies the tracks via their Track Names ({{model-track}}). 
 
-As specified with subscriber interactions, Relays MUST be authorized to serve a given track's Provider and the publisher MUST be authorized to publish content on the tracks advertised in the "PUBLISH" message.
+Publishers MAY be configured to publish the objects to a Relays based on the application configuration and topology. Publishing set of tracks through the Relay starts with a "ANNOUNCE" control messages that identifies the tracks via their Full Track Names ({{model-track}}). 
 
-Relays makes use of priority order and other metadata properties from the published objects to make forward or drop decisions when reacting to congestion as indicated by the underlying QUIC stack.  The same can be used to make caching decisions.
+The "ANNOUNCE" message advertises set of tracks and their authorization information. For each track in the "ANNOUNCE" message,: 
+
+1. For cases where the "Track Namespace" component of the "Full Track Name" is the Origin domain, Relays MUST ensure the Origin is authorized. 
+
+2. Verify that the publisher is authorized to produce on the specified track by validating the authorization information.
+
+Relays respond with "ANNOUNCE OK" and/or "ANNONCE ERROR" control messages reflecting the authorization status.
+
+Relays match the identifiers for the tracks in the OBJECT message published against the list of active subscribers for making forwarding decisions. Relays makes use of priority order and other metadata properties from the published objects to make forward or drop decisions when reacting to congestion as indicated by the underlying QUIC stack.  The same can be used to make caching decisions.
 
 ## Relay Discovery and Failover
 TODO: This section shall cover aspects of relay failover and protocol interactions

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -610,7 +610,7 @@ Publishing through the relay starts with publisher sending "ANNOUNCE" control me
 
 Relays MUST ensure that publishers are authorized by:
 
-- Verifying that the publisher is authorized to publish the content associated with the set of tracks whose Full Track Name share a common prefix with the announced namespace. Specifics of where the authorization happens, either at the relays or forwarded for further processing, depends on the way the relay is managed and is application specific (typically based on prior business agreement). If forwarded, the authorization information from the original annouce control message MUST be identical.
+- Verifying that the publisher is authorized to publish the content associated with the set of tracks whose Full Track Name share a common prefix with the announced namespace. Specifics of where the authorization happens, either at the relays or forwarded for further processing, depends on the way the relay is managed and is application specific (typically based on prior business agreement).
 
 Relays respond with "ANNOUNCE OK" and/or "ANNONCE ERROR" control messages providing the results of announcement.
 

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -500,7 +500,11 @@ and publish requests to the tracks.
 TODO: This section shall cover relay handling of subscriptions.
 
 ## Publisher Interactions
-TODO: This section shall cover relay handling of publishes.
+Publishers MAY be configured to publish the objects to a Relays based on the application configuration and topology.  Publishing set of tracks through the Relay starts with a "PUBLISH" control messages that identifies the tracks via their Track Names ({{model-track}}). 
+
+As specified with subscriber interactions, Relays MUST be authorized to serve a given track's Provider and the publisher MUST be authorized to publish content on the tracks advertised in the "PUBLISH" message.
+
+Relays makes use of priority order and other metadata properties from the published objects to make forward or drop decisions when reacting to congestion as indicated by the underlying QUIC stack.  The same can be used to make caching decisions.
 
 ## Relay Discovery and Failover
 TODO: This section shall cover aspects of relay failover and protocol interactions

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -610,25 +610,26 @@ For successful subscriptions, relays proceed to save the subscription informatio
 
 ## Publisher Interactions
 
-Publishers MAY be configured to publish the objects to a Relays based on the application configuration and topology. Publishing set of tracks through the Relay starts with a "ANNOUNCE" control message
+Publishing through the relay starts with publisher sending "ANNOUNCE" control message for the set of tracks, identified via their Full Track Names ({{model-track}}). Relays MUST ensure that publishers are authorized by:
 
-The "ANNOUNCE" message advertises set of tracks, identified via their Full Track Names ({{model-track}}) and carry necessary authorization information. Relays MUST 
+- Verifying that the publisher is authorized to publish the content associated with the "Full Track Name". The authorization information can be part of annoucement themselves or part of the encompassing session. Specifics of the authorization process depends on the way the relay is managed and is typically based on prior business agreement with the Origin, for example.
 
-- Verify that the publisher is authorized to produce media for a given "Full Track Name" by validating the authorization information. Specifics of the authorization process depends on the way the relay is managed and is typically based on prior business agreement with the Origin, for example.
+Relays respond with "ANNOUNCE OK" and/or "ANNONCE ERROR" control messages providing the results of announcement.
 
-Relays respond with "ANNOUNCE OK" and/or "ANNONCE ERROR" control messages reflecting the authorization status.
-
-Relays MUST match the track id in the OBJECT message header against the active subscribers for a given track. Relays MUST NOT depend on OBJECT payload content for making forwarding decisions and MUST only depend on the fields, such as priority order and other metadata properties in the OBJECT message header. Unless determined by congestion response, Relays MUST forward the OBJECT message to the matching subscribers. 
+OBJECT message header carry short hop-by-hop `Track Id` that maps to the "Full Track Name". Relays MUST use the `Track Id` in the incoming OBJECT messages to find active subscribers with track information matching the `Track Id`. Relays MUST NOT depend on OBJECT payload content for making forwarding decisions and MUST only depend on the fields, such as priority order and other metadata properties in the OBJECT message header. Unless determined by congestion response, Relays MUST forward the OBJECT message to the matching subscribers. 
 
 __Note to authors: This above send behavior is common across all senders and once we have a sufficient text defined elsewhere, we can just refer to the appropriate section.__
 
 ## Relay Discovery and Failover
+
 TODO: This section shall cover aspects of relay failover and protocol interactions
 
 ## Restoring connections through relays
+
 TODO: This section shall cover reconnect considerations for clients when moving between the Relays
 
 ## Congestion Response at Relays
+
 TODO: Refer to {{priority-congestion}}. Add details describe 
 relays behavior when merging or splitting streams and interactions
 with congestion response.

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -611,17 +611,17 @@ For successful subscriptions, Relay proceeds to save the subscription informatio
 
 ## Publisher Interactions
 
-Publishers MAY be configured to publish the objects to a Relays based on the application configuration and topology. Publishing set of tracks through the Relay starts with a "ANNOUNCE" control messages that identifies the tracks via their Full Track Names ({{model-track}}). 
+Publishers MAY be configured to publish the objects to a Relays based on the application configuration and topology. Publishing set of tracks through the Relay starts with a "ANNOUNCE" control message
 
-The "ANNOUNCE" message advertises set of tracks and their authorization information. For each track in the "ANNOUNCE" message,: 
+The "ANNOUNCE" message advertises set of tracks, identified via their Full Track Names ({{model-track}}) and carry necessary authorization information. Relays MUST 
 
-1. For cases where the "Track Namespace" component of the "Full Track Name" is the Origin domain, Relays MUST ensure the Origin is authorized. 
-
-2. Verify that the publisher is authorized to produce on the specified track by validating the authorization information.
+- Verify that the publisher is authorized to produce media for a given "Full Track Name" by validating the authorization information. Specifics of the authorization process depends on the way the relay is managed and is typically based on prior business agreement with the Origin, for example.
 
 Relays respond with "ANNOUNCE OK" and/or "ANNONCE ERROR" control messages reflecting the authorization status.
 
-Relays match the identifiers for the tracks in the OBJECT message published against the list of active subscribers for making forwarding decisions. Relays makes use of priority order and other metadata properties from the published objects to make forward or drop decisions when reacting to congestion as indicated by the underlying QUIC stack.  The same can be used to make caching decisions.
+Relays MUST match the track id in the OBJECT message header against the active subscribers for a given track. Relays MUST NOT depend on OBJECT payload content for making forwarding decisions and MUST only depend on the fields, such as priority order and other metadata properties in the OBJECT message header. Unless determined by congestion response, Relays MUST forward the OBJECT message to the matching subscribers. 
+
+__Note to authors: This above send behavior is common across all senders and once we have a sufficient text defined elsewhere, we can just refer to the appropriate section.__
 
 ## Relay Discovery and Failover
 TODO: This section shall cover aspects of relay failover and protocol interactions

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -610,7 +610,7 @@ Publishing through the relay starts with publisher sending "ANNOUNCE" control me
 
 Relays MUST ensure that publishers are authorized by:
 
-- Verifying that the publisher is authorized to publish the content associated with the set of tracks whose Full Track Name share a common prefix with the announced namespace. Specifics of where the authorization happens, either at the relays or forwarded for further processing, depends on the way the relay is managed and is application specific (typically based on prior business agreement).
+- Verifying that the publisher is authorized to publish the content associated with the set of tracks whose Track Namespace matches the announced namespace. Specifics of where the authorization happens, either at the relays or forwarded for further processing, depends on the way the relay is managed and is application specific (typically based on prior business agreement).
 
 Relays respond with "ANNOUNCE OK" and/or "ANNONCE ERROR" control messages providing the results of announcement.
 


### PR DESCRIPTION
This PR depends on #123 and #125 

The scope of this PR is to add Relay Publish interactions. This is expected to be a starter text and we can add further clarification and details in a separate PR as we develop further.