### PR TITLE
IETF116 : Add a placeholder section for dealing with congestion response

### DIFF
--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -74,6 +74,7 @@ Warp is a live media transport protocol that utilizes the QUIC network protocol 
 * {{motivation}} covers the background and rationale behind Warp.
 * {{objects}} covers how media is fragmented into objects.
 * {{quic}} covers how QUIC is used to transfer media.
+* {{relays-moq}} covers behavior at the relay entities.
 * {{messages}} covers how messages are encoded on the wire.
 * {{containers}} covers how media tracks are packaged.
 
@@ -476,6 +477,36 @@ The endpoint breached an agreement, which MAY have been pre-negotiated by the ap
 * GOAWAY:
 The endpoint successfully drained the session after a GOAWAY was initiated ({{message-goaway}}).
 
+# Relays {#relays-moq}
+
+The Relays play an important role for enabling low latency media delivery within the MoQ architecture. This specification allows for a delivery protocol based on a publish/subscribe metaphor where some endpoints, called publishers, publish media objects and
+some endpoints, called subscribers, consume those media objects. Relays leverage this publish/subscribe metaphor to form an overlay delivery network similar/in-parallel to what CDN provides today.
+
+Relays provide several benefits including
+
+* Scalability – Relays provide the fan-out necessary to scale up streams to production levels (millions) of concurrent subscribers.
+
+* Reliability - Relays can improve the overall reliability of the delivery system by providing alternate paths for routing content.
+
+* Performance – Relays are usually positioned as close to the edge  of a network as possible and are well-connected to each other and to the Origin via high capacity managed networks. This topography minimizes the RTT over the unmanaged last mile to the end-user, improving the latency and throughput  compared to the client connecting directly to the origin.'
+
+* Security – Relays act to shield the origin from DDOS and other malicious attacks.
+
+
+Relays serves as policy enforcement points by validating subscribe
+and publish requests to the tracks.
+
+## Subscriber Interactions
+TODO: This section shall cover relay handling of subscriptions.
+
+## Publisher Interactions
+TODO: This section shall cover relay handling of publishes.
+
+## Relay Discovery and Failover
+TODO: This section shall cover aspects of relay failover and protocol interactions
+
+## Restoring connections through relays
+TODO: This section shall cover reconnect considerations for clients when moving between the Relays
 
 # Messages
 Both unidirectional and bidirectional Warp streams are sequences of length-deliminated messages.

--- a/draft-lcurley-warp.md
+++ b/draft-lcurley-warp.md
@@ -74,6 +74,7 @@ Warp is a live media transport protocol that utilizes the QUIC network protocol 
 * {{motivation}} covers the background and rationale behind Warp.
 * {{objects}} covers how media is fragmented into objects.
 * {{quic}} covers how QUIC is used to transfer media.
+* {{congestion-response}} covers protocol considerations for delaing with congestion overall.
 * {{relays-moq}} covers behavior at the relay entities.
 * {{messages}} covers how messages are encoded on the wire.
 * {{containers}} covers how media tracks are packaged.
@@ -308,6 +309,9 @@ Any identification, reliability, ordering, prioritization, caching, etc is writt
 This ensures that relays can easily route/fanout media to the final destination.
 This also ensures that congestion response is consistent at every hop based on the preferences of the media producer.
 
+## Bandwidth Management and Congestion Response
+TODO: Add text descibing congestion response at Relays. This requires addressing details on reactions to congestion via starve or drop, relay performing local choices or susbcribers adapting to change in network bandwidth. This should refer to {{congestion-response}}.
+
 
 # Objects
 Warp works by splitting media into objects that can be transferred over QUIC streams.
@@ -352,6 +356,11 @@ A receiver MUST NOT assume that objects will be received in delivery order for a
 * Packet loss or flow control MAY delay the delivery of individual streams.
 * The sender might not support QUIC stream prioritization.
 
+TODO: Refer to Congestion Response and Priorirization Section for further details on various proposals.
+
+## Groups
+TODO: Add text describing interation of group and intra object priorities within a group and their relation to congestion response.
+Add how it refers to {{congestion-response}}
 
 ## Decoder
 The decoder will receive multiple objects in parallel and out of order.
@@ -399,7 +408,10 @@ Messages SHOULD be sent over the same stream if ordering is desired.
 ## Prioritization
 Warp utilizes stream prioritization to deliver the most important content during congestion.
 
+TODO: Revisit the prioritization scheme and possibly move some fo this to {{congestion-response}}.
+
 The producer may assign a numeric delivery order to each object ({{delivery-order}})
+
 This is a strict prioritization scheme, such that any available bandwidth is allocated to streams in ascending priority order.
 The sender SHOULD prioritize streams based on the delivery order.
 If two streams have the same delivery order, they SHOULD receive equal bandwidth (round-robin).
@@ -448,6 +460,8 @@ Most TCP congestion control algorithms will only increase the congestion window 
 Senders SHOULD use a congestion control algorithm that is designed for application-limited flows (ex. GCC).
 Senders MAY periodically pad the connection with QUIC PING frames to fill the congestion window.
 
+TODO: update this section to refer to {{congestion-response}}
+
 ## Termination
 The WebTransport session can be terminated at any point with CLOSE\_WEBTRANSPORT\_SESSION capsule, consisting of an integer code and string message.
 
@@ -476,6 +490,17 @@ The endpoint breached an agreement, which MAY have been pre-negotiated by the ap
 
 * GOAWAY:
 The endpoint successfully drained the session after a GOAWAY was initiated ({{message-goaway}}).
+
+# Congestion Response Considerations {#congestion-response}
+
+TODO: This is a placeholder section to capture details on
+how the Moq Transport protocol deals with congestion overall. Having its own section helps reduce merge conflicts and allows us to reference it from other parts.
+
+This section is expected to cover:
+
+- Object Metadata Details
+- Proposal sections on sendOrder, object priorities model
+- Mapping and adaptation considerations to one object per stream vs multiple objects per stream
 
 # Relays {#relays-moq}
 
@@ -507,6 +532,9 @@ TODO: This section shall cover aspects of relay failover and protocol interactio
 
 ## Restoring connections through relays
 TODO: This section shall cover reconnect considerations for clients when moving between the Relays
+
+## Congestion Response at Relays
+TODO: Refer to {{congestion-response}}
 
 # Messages
 Both unidirectional and bidirectional Warp streams are sequences of length-deliminated messages.


### PR DESCRIPTION
This PR adds a placeholder section for inserting details on various congestion response and prioritization proposals being discussed.  At IETF116 , it was very clear that there are couple of ways this can be address and having its own section would help along as we go further.